### PR TITLE
Fix wrong interactive value

### DIFF
--- a/src/chat/botman.ts
+++ b/src/chat/botman.ts
@@ -21,7 +21,7 @@ class BotMan {
     		userId: this.userId,
     		message: text,
     		attachment: attachment as Blob,
-    		interactive: interactive ? '1' : 'o'
+    		interactive: interactive ? '1' : '0'
     	};
 
     	Object.keys(postData).forEach(key => data.append(key, postData[key]));

--- a/src/chat/botman.ts
+++ b/src/chat/botman.ts
@@ -21,7 +21,7 @@ class BotMan {
     		userId: this.userId,
     		message: text,
     		attachment: attachment as Blob,
-    		interactive: interactive ? '0' : '1'
+    		interactive: interactive ? '1' : 'o'
     	};
 
     	Object.keys(postData).forEach(key => data.append(key, postData[key]));


### PR DESCRIPTION
The current version of the web widget sends 0 when interactive is true and 1 when it's false. This PR fixes this behaviour.