### PR TITLE
Add userId param to widgetOpened event

### DIFF
--- a/src/widget/widget.tsx
+++ b/src/widget/widget.tsx
@@ -156,6 +156,7 @@ export default class Widget extends Component<any, IWidgetState> {
         data.append('driver', 'web');
         data.append('eventName', 'widgetOpened');
         data.append('eventData', this.props.conf.widgetOpenedEventData);
+        data.append('userId', window.botmanWidget.userId);
 
         axios.post(this.props.conf.chatServer, data).then(response => {
             const messages = response.data.messages || [];


### PR DESCRIPTION
If I am trying to  start conversation with user from widgetOpened event, like this:
```js
//index.html
var botmanWidget = {
sendWidgetOpenedEvent: 1
}
```
```php
//bot.php
$botman->hears('(.*)', function ($bot){
    $bot->startConversation(new WelcomeConversation());
});
```
I see in my cache conversation duplicates  (and in UI too):
```sh
root@scw:~# redis-cli KEYS '*'
1) "botman:cache:conversation-da39a3ee5e6b4b0d3255bfef95601890afd80709-da39a3ee5e6b4b0d3255bfef95601890afd80709"
2) "botman:cache:conversation-0409cb8558ad20d53c230f23e83cc64e15b6fa70-0409cb8558ad20d53c230f23e83cc64e15b6fa70"
```
The first hash is constantly equals `sha1("")` . The reason is widgetOpened event, which raise first instance of conversation, has no binding to any user.

With my fix all seems to work ok.