### PR TITLE
Added alt text for chat bubble avatar

### DIFF
--- a/src/widget/chat-floating-button.tsx
+++ b/src/widget/chat-floating-button.tsx
@@ -27,6 +27,7 @@ export default class ChatFloatingButton extends Component<IChatFloatingButtonPro
                             <img
                                 src={conf.bubbleAvatarUrl}
                                 style={{...closedChatAvatarImageStyle}}
+                                alt="chat-bubble-avatar"
                             />: <div style={{ display: 'flex', alignItems: 'center' }}><br/>{conf.bubbleAvatarUrl}</div>)
                     }
                 </div>


### PR DESCRIPTION
Image elements do not have [alt] attributes error was thrown on Lighthouse. This affects pages accessibility. I have added a default alt tag for the <img> element. I think we don't have to let the user configure this so I just added alt="chat-bubble-avatar" for the <img> element.