### PR TITLE
Added ability to send extra params and initialize widget on demand.

### DIFF
--- a/src/chat/botman.ts
+++ b/src/chat/botman.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
-import { IAttachment, IMessage } from './../typings';
+import { IAttachment, IMessage, IExtra } from './../typings';
 
 class BotMan {
 
+	extra: IExtra;
 	userId: string;
 	chatServer: string;
 
@@ -12,7 +13,11 @@ class BotMan {
 
     setChatServer(chatServer: string) {
         this.chatServer = chatServer;
-    }
+	}
+	
+	setExtra(params: IExtra) {
+		this.extra = params;
+	}
 
     callAPI = (text: string, interactive = false, attachment: IAttachment = null, perMessageCallback: Function, callback: Function) => {
     	let data = new FormData();
@@ -22,8 +27,13 @@ class BotMan {
     		message: text,
     		attachment: attachment as Blob,
     		interactive: interactive ? '1' : '0'
-    	};
+		};
+		
+		if (this.extra) {
 
+			Object.keys(this.extra).forEach(key => data.append(key, this.extra[key]));
+		}
+	
     	Object.keys(postData).forEach(key => data.append(key, postData[key]));
 
     	axios.post(this.chatServer, data).then(response => {

--- a/src/chat/chat.tsx
+++ b/src/chat/chat.tsx
@@ -1,7 +1,7 @@
 import { h, Component } from "preact";
 import MessageArea from "./message-area";
 import { botman } from "./botman";
-import {IMessage, IConfiguration} from "../typings";
+import {IMessage, IConfiguration, IExtra} from "../typings";
 
 export default class Chat extends Component<IChatProps, IChatState> {
 
@@ -68,6 +68,10 @@ export default class Chat extends Component<IChatProps, IChatState> {
 
     whisper(text: string) {
         this.say(text, false);
+    }
+
+    setExtra(params: IExtra) {
+        this.botman.setExtra(params);
     }
 
     render({}, state: IChatState) {

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -68,6 +68,10 @@ export interface IAction {
 
 export interface IConfiguration {
     /**
+     * Automatically initialize the chat widget.
+     */
+    autoInit: boolean,
+    /**
      * The URL of the BotMan route / server to use.
      */
     chatServer: string,
@@ -133,4 +137,8 @@ export interface IConfiguration {
     echoEventName: string,
 
     init?: Function
+}
+
+export interface IExtra { 
+    [index: string] : string 
 }

--- a/src/widget/api.ts
+++ b/src/widget/api.ts
@@ -1,5 +1,5 @@
 import Widget from './widget';
-import {IMessage} from "../typings";
+import {IMessage, IExtra} from "../typings";
 
 export default class Api {
 
@@ -76,4 +76,20 @@ export default class Api {
         });
     }
 
+    setExtra(extra: IExtra) {
+
+        const wasClosed = !this.isOpen();
+
+        this.callChatWidget({
+            method: 'setExtra',
+            params: [
+                extra
+            ]
+        });
+
+        if (wasClosed) {
+
+            this.close();
+        }
+    }
 }

--- a/src/widget/configuration.ts
+++ b/src/widget/configuration.ts
@@ -1,6 +1,7 @@
 import { IConfiguration } from "../typings";
 
 export const defaultConfiguration: IConfiguration = {
+    autoInit: true,
     chatServer: '/botman',
     frameEndpoint: '/botman/chat',
     timeFormat: 'HH:MM',

--- a/src/widget/index.tsx
+++ b/src/widget/index.tsx
@@ -4,9 +4,9 @@ import {defaultConfiguration} from './configuration';
 import {IConfiguration} from "../typings";
 
 if (window.attachEvent) {
-    window.attachEvent('onload', injectChat);
+    window.attachEvent('onload', initialize);
 } else {
-    window.addEventListener('load', injectChat, false);
+    window.addEventListener('load', initialize, false);
 }
 
 function getUrlParameter(name: string, defaults = '') {
@@ -20,14 +20,7 @@ function getUserId(conf: IConfiguration) {
     return conf.userId || generateRandomId();
 }
 
-function generateRandomId() {
-    return Math.random().toString(36).substr(2, 6);
-}
-
-function injectChat() {
-    let root = document.createElement('div');
-    root.id = 'botmanWidgetRoot';
-    document.getElementsByTagName('body')[0].appendChild(root);
+function getConfig () :IConfiguration {
 
     let settings = {};
     try {
@@ -42,7 +35,30 @@ function injectChat() {
         dynamicConf.echoChannel = dynamicConf.echoChannel(dynamicConf.userId);
     }
 
-    const conf = {...defaultConfiguration, ...settings, ...dynamicConf};
+    return {...defaultConfiguration, ...settings, ...dynamicConf};
+}
+
+function generateRandomId() {
+    return Math.random().toString(36).substr(2, 6);
+}
+
+function initialize () {
+
+    const conf = getConfig();
+
+    if (conf.autoInit) {
+        injectChat();
+    } else {
+        window.botmanInit = injectChat;
+    }
+}
+
+function injectChat() {
+    let root = document.createElement('div');
+    root.id = 'botmanWidgetRoot';
+    document.getElementsByTagName('body')[0].appendChild(root);
+
+    const conf = getConfig();
 
     const iFrameSrc = conf.frameEndpoint;
 
@@ -55,8 +71,9 @@ function injectChat() {
         root
     );
 
+    delete window.botmanInit;
 }
 
 declare global {
-    interface Window { attachEvent: Function, botmanWidget: IConfiguration }
+    interface Window { attachEvent: Function, botmanWidget: IConfiguration, botmanInit: Function }
 }


### PR DESCRIPTION
I've added the following features:
- ability to send extra params (referencing #11);
- initialize botman widget on demand;

# Ability to send extra params

Sometimes you may need to send additional parameters such as tokens, which are only available on the client side. The widget should also support setting these parameters later on (after initialization) in case they change. It should be used with caution because it needs to render the iframe used for the chat.

# Initialize botman widget

The widget should offer the ability to initialize only after a certain action occurred, such as user login.
